### PR TITLE
Adding "eat" procedure to move the contents of one chest into another.

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -263,9 +263,9 @@ class Chest(MutableMapping):
         food.flush()
         for key in food._keys:
             if key in self._keys and overwrite:
-              del self[key]  
+                del self[key]
             elif key in self._keys and not overwrite:
-              continue
+                continue
             old_fn = os.path.join(food.path, food._key_to_filename(key))
             new_fn = os.path.join(self.path, self._key_to_filename(key))
             os.rename(old_fn, new_fn)

--- a/chest/core.py
+++ b/chest/core.py
@@ -257,20 +257,20 @@ class Chest(MutableMapping):
                 eValue = eType(eValue)  # pragma: no cover
             raise eValue
 
-    def eat(self, food, overwrite=True):
-        """ Move the contents of chest food to this chest """
+    def update(self, other, overwrite=True):
+        """ Copy (hard-link) the contents of chest other to this chest """
         #  if already flushed, then this does nothing
-        food.flush()
-        for key in food._keys:
+        self.flush()
+        other.flush()
+        for key in other._keys:
             if key in self._keys and overwrite:
                 del self[key]
             elif key in self._keys and not overwrite:
                 continue
-            old_fn = os.path.join(food.path, food._key_to_filename(key))
+            old_fn = os.path.join(other.path, other._key_to_filename(key))
             new_fn = os.path.join(self.path, self._key_to_filename(key))
-            os.rename(old_fn, new_fn)
+            os.link(old_fn, new_fn)
             self._keys.add(key)
-        food.drop()
 
 
 def nbytes(o):

--- a/chest/core.py
+++ b/chest/core.py
@@ -257,6 +257,21 @@ class Chest(MutableMapping):
                 eValue = eType(eValue)  # pragma: no cover
             raise eValue
 
+    def eat(self, food, overwrite=True):
+        """ Move the contents of chest food to this chest """
+        #  if already flushed, then this does nothing
+        food.flush()
+        for key in food._keys:
+            if key in self._keys and overwrite:
+              del self[key]  
+            elif key in self._keys and not overwrite:
+              continue
+            old_fn = os.path.join(food.path, food._key_to_filename(key))
+            new_fn = os.path.join(self.path, self._key_to_filename(key))
+            os.rename(old_fn, new_fn)
+            self._keys.add(key)
+        food.drop()
+
 
 def nbytes(o):
     """ Number of bytes of an object

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -302,3 +302,28 @@ def test_undumpable_values_stay_in_memory():
 
         assert 'a' in c.inmem
         assert not os.path.exists(c.key_to_filename('a'))
+
+def test_eat():
+    with tmp_chest() as c1:
+        with tmp_chest() as c2:
+          c1['foo'] = 'bar'
+          c1['bar'] = 'bbq'
+          c2['bar'] = 'foo'
+          c2['spam'] = 'eggs'
+          c1.eat(c2)
+          assert c1['foo']  == 'bar'
+          assert c1['bar']  == 'foo'
+          assert c1['spam'] == 'eggs'
+
+def test_eat_no_overwrite():
+    with tmp_chest() as c1:
+        with tmp_chest() as c2:
+          c1['foo'] = 'bar'
+          c1['bar'] = 'bbq'
+          c2['bar'] = 'foo'
+          c2['spam'] = 'eggs'
+          c1.eat(c2, overwrite=False)
+          assert c1['foo']  == 'bar'
+          assert c1['bar']  == 'bbq'
+          assert c1['spam'] == 'eggs'
+

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -303,27 +303,28 @@ def test_undumpable_values_stay_in_memory():
         assert 'a' in c.inmem
         assert not os.path.exists(c.key_to_filename('a'))
 
+
 def test_eat():
     with tmp_chest() as c1:
         with tmp_chest() as c2:
-          c1['foo'] = 'bar'
-          c1['bar'] = 'bbq'
-          c2['bar'] = 'foo'
-          c2['spam'] = 'eggs'
-          c1.eat(c2)
-          assert c1['foo']  == 'bar'
-          assert c1['bar']  == 'foo'
-          assert c1['spam'] == 'eggs'
+            c1['foo'] = 'bar'
+            c1['bar'] = 'bbq'
+            c2['bar'] = 'foo'
+            c2['spam'] = 'eggs'
+            c1.eat(c2)
+            assert c1['foo']  == 'bar'
+            assert c1['bar']  == 'foo'
+            assert c1['spam'] == 'eggs'
+
 
 def test_eat_no_overwrite():
     with tmp_chest() as c1:
         with tmp_chest() as c2:
-          c1['foo'] = 'bar'
-          c1['bar'] = 'bbq'
-          c2['bar'] = 'foo'
-          c2['spam'] = 'eggs'
-          c1.eat(c2, overwrite=False)
-          assert c1['foo']  == 'bar'
-          assert c1['bar']  == 'bbq'
-          assert c1['spam'] == 'eggs'
-
+            c1['foo'] = 'bar'
+            c1['bar'] = 'bbq'
+            c2['bar'] = 'foo'
+            c2['spam'] = 'eggs'
+            c1.eat(c2, overwrite=False)
+            assert c1['foo']  == 'bar'
+            assert c1['bar']  == 'bbq'
+            assert c1['spam'] == 'eggs'

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -116,6 +116,11 @@ def test_flush():
         c.flush()
         assert os.path.exists(c.key_to_filename(1))
         assert os.path.exists(c.key_to_filename(2))
+        c[1] = 'two'
+        c[2] = 'one'
+        c.flush()
+        assert c[1] == 'two'
+        assert c[2] == 'one'
 
 
 def test_keys_values_items():
@@ -311,7 +316,7 @@ def test_eat():
             c1['bar'] = 'bbq'
             c2['bar'] = 'foo'
             c2['spam'] = 'eggs'
-            c1.eat(c2)
+            c1.update(c2)
             assert c1['foo'] == 'bar'
             assert c1['bar'] == 'foo'
             assert c1['spam'] == 'eggs'
@@ -324,7 +329,22 @@ def test_eat_no_overwrite():
             c1['bar'] = 'bbq'
             c2['bar'] = 'foo'
             c2['spam'] = 'eggs'
-            c1.eat(c2, overwrite=False)
+            c1.update(c2, overwrite=False)
             assert c1['foo'] == 'bar'
             assert c1['bar'] == 'bbq'
             assert c1['spam'] == 'eggs'
+
+
+def test_update():
+    with tmp_chest() as c1:
+        with tmp_chest() as c2:
+            c1['foo'] = 'bar'
+            c1['bar'] = 'bbq'
+            c2['bar'] = 'foo'
+            c2['spam'] = 'eggs'
+            c1.update(c2)
+            assert c1['foo'] == 'bar'
+            assert c1['bar'] == 'foo'
+            assert c1['spam'] == 'eggs'
+            assert c2['bar'] == 'foo'
+            assert c2['spam'] == 'eggs'

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -312,8 +312,8 @@ def test_eat():
             c2['bar'] = 'foo'
             c2['spam'] = 'eggs'
             c1.eat(c2)
-            assert c1['foo']  == 'bar'
-            assert c1['bar']  == 'foo'
+            assert c1['foo'] == 'bar'
+            assert c1['bar'] == 'foo'
             assert c1['spam'] == 'eggs'
 
 
@@ -325,6 +325,6 @@ def test_eat_no_overwrite():
             c2['bar'] = 'foo'
             c2['spam'] = 'eggs'
             c1.eat(c2, overwrite=False)
-            assert c1['foo']  == 'bar'
-            assert c1['bar']  == 'bbq'
+            assert c1['foo'] == 'bar'
+            assert c1['bar'] == 'bbq'
             assert c1['spam'] == 'eggs'


### PR DESCRIPTION
c1.eat(c2) flushes c2, moves c2's files into c1's directory, and
adds c2's keys to c1.  By default, keys in c2 overwrite the same
keys in c1, but that behavior can be controlled by overwrite=False.