### PR TITLE
Tuple keys move files into directories

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -98,13 +98,10 @@ class Chest(MutableMapping):
         self.mode = mode
         self._key_to_filename = key_to_filename
 
-        if os.path.exists(self.path):
-            keyfile = os.path.join(self.path, '.keys')
-            if os.path.exists(keyfile):
-                with open(keyfile, mode='r'+self.mode) as f:
-                    self._keys = set(self.load(f))
-        else:
-            os.mkdir(self.path)
+        keyfile = os.path.join(self.path, '.keys')
+        if os.path.exists(keyfile):
+            with open(keyfile, mode='r'+self.mode) as f:
+                self._keys = set(self.load(f))
 
         self.lock = Lock()
 

--- a/chest/core.py
+++ b/chest/core.py
@@ -22,8 +22,8 @@ def key_to_filename(key):
     if isinstance(key, str) and re.match('^[_a-zA-Z]\w*$', key):
         return key
     if isinstance(key, tuple):
-        names = (['_' + key_to_filename(k) for k in key[:-1]]
-                + [key_to_filename(key[-1])])
+        names = (['_' + key_to_filename(k) for k in key[:-1]] +
+                 [key_to_filename(key[-1])])
         return os.path.join(*names)
     else:
         return str(hashlib.md5(str(key).encode()).hexdigest())

--- a/chest/core.py
+++ b/chest/core.py
@@ -21,6 +21,10 @@ def key_to_filename(key):
     """
     if isinstance(key, str) and re.match('^[_a-zA-Z]\w*$', key):
         return key
+    if isinstance(key, tuple):
+        names = (['_' + key_to_filename(k) for k in key[:-1]]
+                + [key_to_filename(key[-1])])
+        return os.path.join(*names)
     else:
         return str(hashlib.md5(str(key).encode()).hexdigest())
 
@@ -124,6 +128,9 @@ class Chest(MutableMapping):
         self._on_overflow(key)
         fn = self.key_to_filename(key)
         if not os.path.exists(fn):  # Only write if it doesn't exist.
+            dir = os.path.dirname(fn)
+            if not os.path.exists(dir):
+                os.makedirs(dir)
             try:
                 with open(fn, mode='w'+self.mode) as f:
                     self.dump(self.inmem[key], f)

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -381,7 +381,6 @@ def test_nested_files_with_tuples():
         assert any(os.path.isdir(os.path.join(c.path, p)) for p in paths)
         assert any(not os.path.isdir(os.path.join(c.path, p)) for p in paths)
 
-
         c['a', 'b', 'c', 'd', 'e'] = 5
         c.flush()
         assert c['a', 'b', 'c', 'd', 'e'] == 5


### PR DESCRIPTION
Example
-------

```Python
    In [1]: from chest import Chest

    In [2]: c = Chest(path='foo')

    In [3]: c['one'] = 1

    In [4]: c['one', 'two'] = 12

    In [5]: c['one', 'three'] = 13

    In [6]: c.flush()

    In [7]: !tree foo
    foo
    ├── one
    └── _one
        ├── three
        └── two

        1 directory, 3 files
```

cc @maxhutch