### PR TITLE
Store filenames

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -123,7 +123,7 @@ class Chest(MutableMapping):
     def move_to_disk(self, key):
         """ Move data from memory onto disk """
         self._on_overflow(key)
-        fn = self.key_to_filename(key)
+        fn = self._keys[key]
         if not os.path.exists(fn):  # Only write if it doesn't exist.
             dir = os.path.dirname(fn)
             if not os.path.exists(dir):
@@ -143,7 +143,7 @@ class Chest(MutableMapping):
 
         self._on_miss(key)
 
-        fn = self.key_to_filename(key)
+        fn = self._keys[key]
         with open(fn, mode='r'+self.mode) as f:
             value = self.load(f)
 
@@ -176,7 +176,7 @@ class Chest(MutableMapping):
         if key in self.heap:
             del self.heap[key]
 
-        fn = self.key_to_filename(key)
+        fn = self._keys[key]
         if os.path.exists(fn):
             os.remove(fn)
 
@@ -275,7 +275,7 @@ class Chest(MutableMapping):
                 del self[key]
             elif key in self._keys and not overwrite:
                 continue
-            old_fn = other._keys[key] 
+            old_fn = other._keys[key]
             new_fn = os.path.join(self.path, self._key_to_filename(key))
             dir = os.path.dirname(new_fn)
             if not os.path.exists(dir):

--- a/chest/core.py
+++ b/chest/core.py
@@ -154,7 +154,7 @@ class Chest(MutableMapping):
             if key in self.inmem:
                 value = self.inmem[key]
             else:
-                if key not in self._keys.keys():
+                if key not in self._keys:
                     raise KeyError("Key not found: %s" % key)
 
                 self.get_from_disk(key)
@@ -184,7 +184,7 @@ class Chest(MutableMapping):
 
     def __setitem__(self, key, value):
         with self.lock:
-            if key in self._keys.keys():
+            if key in self._keys:
                 del self[key]
 
             self.inmem[key] = value
@@ -202,13 +202,13 @@ class Chest(MutableMapping):
                 self.drop()  # pragma: no cover
 
     def __iter__(self):
-        return iter(self._keys.keys())
+        return iter(self._keys)
 
     def __len__(self):
-        return len(self._keys.keys())
+        return len(self._keys)
 
     def __contains__(self, key):
-        return key in self._keys.keys()
+        return key in self._keys
 
     @property
     def memory_usage(self):
@@ -242,7 +242,7 @@ class Chest(MutableMapping):
     def write_keys(self):
         fn = os.path.join(self.path, '.keys')
         with open(fn, mode='w'+self.mode) as f:
-            self.dump(list(iter(self._keys.items())), f)
+            self.dump(list(self._keys.items()), f)
 
     def flush(self):
         """ Flush all in-memory storage to disk """
@@ -270,7 +270,7 @@ class Chest(MutableMapping):
         #  if already flushed, then this does nothing
         self.flush()
         other.flush()
-        for key in other._keys.keys():
+        for key in other._keys:
             if key in self._keys and overwrite:
                 del self[key]
             elif key in self._keys and not overwrite:

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 import numpy as np
 from chest.utils import raises
 import time
+import hashlib
 
 
 @contextmanager
@@ -25,6 +26,11 @@ def tmp_chest(*args, **kwargs):
             del c
         except:
             pass
+
+
+def my_key_to_fname(key):
+    fname = str(hashlib.md5(str(key).encode()).hexdigest())
+    return fname
 
 
 def test_basic():
@@ -384,3 +390,13 @@ def test_nested_files_with_tuples():
         c['a', 'b', 'c', 'd', 'e'] = 5
         c.flush()
         assert c['a', 'b', 'c', 'd', 'e'] == 5
+
+
+def test_store_fnames():
+    with tmp_chest(key_to_filename=my_key_to_fname) as c1:
+        c1[('spam', 'eggs')] = 'spam and eggs'
+        c1.flush()
+        with tmp_chest() as c2:
+            c2.update(c1)
+            c2.flush()
+            assert c2[('spam', 'eggs')] == 'spam and eggs'


### PR DESCRIPTION
Filenames are stored along with keys, making old chests more portable. _keys, which was a set, is replaced with a {key -> filename} dictionary.  The dictionary is dumped/loaded as a list of tuples for json compatibility, but used as a dict internally.