### PR TITLE
Bugfix: if dump() was called, del can't write keys during flush.

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -196,7 +196,12 @@ class Chest(MutableMapping):
 
     def __del__(self):
         if self._explicitly_given_path:
-            self.flush()
+            if os.path.exists(self.path):
+                self.flush()
+            else:
+                with self.lock:
+                    for key in list(self.inmem):
+                        del self.inmem[key]
         elif os.path.exists(self.path):
             with self.lock:
                 self.drop()  # pragma: no cover


### PR DESCRIPTION
This just checks if dump has been called (by seeing if self.path
exists).  It dump was called, then delete the contents of self.inmem
but don't move them to disk or write keys.

This gets rid of the exceptions that were briefly mentioned in #4 