### PR TITLE
Pass an open routine to the constructor.

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -81,7 +81,7 @@ class Chest(MutableMapping):
                  load=pickle.load,
                  key_to_filename=key_to_filename,
                  on_miss=_do_nothing, on_overflow=_do_nothing,
-                 _open=open,
+                 open=open,
                  mode='b'):
         # In memory storage
         self.inmem = data or dict()
@@ -101,7 +101,7 @@ class Chest(MutableMapping):
         self.load = load
         self.dump = dump
         self.mode = mode
-        self.open = _open
+        self.open = open
         self._key_to_filename = key_to_filename
 
         keyfile = os.path.join(self.path, '.keys')


### PR DESCRIPTION
The only real change here is trying to open the .keys file, instead
of calling os.exists, to allow open to work some magic.