### PR TITLE
Added cache_many method and open_many constructor argument.

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -306,6 +306,7 @@ class Chest(MutableMapping):
             os.link(old_fn, new_fn)
 
     def prefetch(self, keys):
+        """ Fetch a list of pairs into memory """
         if not isinstance(keys, list):
             keys = [keys, ]
         keys = [k for k in keys if k not in self.inmem]

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -28,16 +28,6 @@ def tmp_chest(*args, **kwargs):
             pass
 
 
-@contextmanager
-def open_many(fnames, mode='rb'):
-    fs = []
-    for fn in fnames:
-        fs.append(open(fn, mode=mode))
-    yield fs
-    for f in fs:
-        f.close()
-
-
 def my_key_to_fname(key):
     fname = str(hashlib.md5(str(key).encode()).hexdigest())
     return fname
@@ -456,7 +446,7 @@ def test_memory_usage():
         assert c.memory_usage == 0
 
 
-def test_cache_many():
+def test_prefetch():
     with tmp_chest(on_miss=raise_KeyError) as c:
         c[1] = 1
         c[2] = 2
@@ -464,21 +454,7 @@ def test_cache_many():
         assert not raises(KeyError, lambda: c[1])
         c.flush()
         assert raises(KeyError, lambda: c[1])
-        c.cache_many(1)
+        c.prefetch(1)
         assert not raises(KeyError, lambda: c[1])
-        c.cache_many([1, 2])
-        assert not raises(KeyError, lambda: c[2])
-
-
-def test_open_many():
-    with tmp_chest(open_many=open_many, on_miss=raise_KeyError) as c:
-        c[1] = 1
-        c[2] = 2
-        c[3] = 3
-        assert not raises(KeyError, lambda: c[1])
-        c.flush()
-        assert raises(KeyError, lambda: c[1])
-        c.cache_many(1)
-        assert not raises(KeyError, lambda: c[1])
-        c.cache_many([1, 2])
+        c.prefetch([1, 2])
         assert not raises(KeyError, lambda: c[2])

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -6,7 +6,7 @@ import shutil
 import pickle
 from contextlib import contextmanager
 import numpy as np
-from chest.utils import raises
+from chest.utils import raises, raise_KeyError
 import time
 import hashlib
 
@@ -26,6 +26,16 @@ def tmp_chest(*args, **kwargs):
             del c
         except:
             pass
+
+
+@contextmanager
+def open_many(fnames, mode='rb'):
+    fs = []
+    for fn in fnames:
+        fs.append(open(fn, mode=mode))
+    yield fs
+    for f in fs:
+        f.close()
 
 
 def my_key_to_fname(key):
@@ -444,3 +454,31 @@ def test_memory_usage():
 
         c.flush()
         assert c.memory_usage == 0
+
+
+def test_cache_many():
+    with tmp_chest(on_miss=raise_KeyError) as c:
+        c[1] = 1
+        c[2] = 2
+        c[3] = 3
+        assert not raises(KeyError, lambda: c[1])
+        c.flush()
+        assert raises(KeyError, lambda: c[1])
+        c.cache_many(1)
+        assert not raises(KeyError, lambda: c[1])
+        c.cache_many([1, 2])
+        assert not raises(KeyError, lambda: c[2])
+
+
+def test_open_many():
+    with tmp_chest(open_many=open_many, on_miss=raise_KeyError) as c:
+        c[1] = 1
+        c[2] = 2
+        c[3] = 3
+        assert not raises(KeyError, lambda: c[1])
+        c.flush()
+        assert raises(KeyError, lambda: c[1])
+        c.cache_many(1)
+        assert not raises(KeyError, lambda: c[1])
+        c.cache_many([1, 2])
+        assert not raises(KeyError, lambda: c[2])

--- a/chest/utils.py
+++ b/chest/utils.py
@@ -4,3 +4,7 @@ def raises(err, lamda):
         return False
     except err:
         return True
+
+
+def raise_KeyError(key):
+    raise KeyError("I asked for one of these %s" % key)


### PR DESCRIPTION
cache_many loads a list of keys to the in-cache memory.

open_many take a list of filenames and returns a list of open files.
This is mostly to support overloading of open.